### PR TITLE
Review comments on -23

### DIFF
--- a/draft-ietf-idr-bgp-ct.xml
+++ b/draft-ietf-idr-bgp-ct.xml
@@ -68,7 +68,7 @@
       group underlay routes with sufficiently similar TE characteristics into
       identifiable classes (called "Transport Classes"), that overlay routes
       use as an ordered set to resolve reachability (Resolution Schemes)
-      towards service endpoints. These constructs can be used e.g., to realize
+      towards service endpoints. These constructs can be used, for example, to realize
       the "IETF Network Slice" defined in TEAS Network Slices framework.</t>
 
       <t>Additionally, this document specifies protocol procedures for BGP
@@ -94,7 +94,7 @@
   <middle>
     <section title="Introduction">
       <t>Provider networks typically span across multiple domains where each
-      domain can either represent an Autonomous system (AS) or an Interior
+      domain can either represent an Autonomous System (AS) or an Interior
       Gateway Protocol (IGP) region within an AS. In these networks, several
       services are provisioned between different pairs of service endpoints
       (e.g., Provider Edge (PE) nodes), that can either be in the same domain
@@ -107,13 +107,13 @@
 
       <t>The mechanisms described in this document achieve "Intent Driven
       Service Mapping" between any pair of service endpoints by:<list>
-          <t>provisioning end-to-end "intent-aware" paths (e.g., low latency
-          path, best effort path) using BGP,</t>
+	  <t>Provisioning end-to-end "intent-aware" paths using BGP.  For
+	  example, low latency path, best effort path.</t>
 
-          <t>expressing a desired intent (e.g., use low latency path with
-          fallback to the best effort path), and</t>
+          <t>Expressing a desired intent. For example, use low latency path with
+          fallback to the best effort path.</t>
 
-          <t>forwarding service traffic "only" using end-to-end "intent-aware"
+          <t>Forwarding service traffic "only" using end-to-end "intent-aware"
           paths honoring that desired intent.</t>
         </list></t>
 
@@ -127,9 +127,10 @@
       service node or a border node, that service traffic use to traverse that
       domain. These tunnels are signaled using various tunneling protocols
       depending on the forwarding architecture used in the domain, which can
-      be Multi Protocol Label Switching (MPLS), Internet Protocol version 4
+      be Multiprotocol Label Switching (MPLS), Internet Protocol version 4
       (IPv4), or Internet Protocol version 6 (IPv6).</t>
 
+      <!-- XXX JMH - greenfield/brownfield not defined - need definitions? -->
       <t>The mechanisms defined in this document allow different tunneling
       technologies to become Transport Class aware. These can be applied
       homogeneously to intra-domain tunneling technologies used in brownfield
@@ -232,6 +233,8 @@
 
       <t>TN: Transport Node, P-router</t>
 
+      <t>TRDB: Transport Route Database</t>
+
       <t>UHP: Ultimate Hop Pop</t>
 
       <t>VRF: Virtual Routing and Forwarding table</t>
@@ -260,7 +263,7 @@
         them, as defined in Section 2 of <xref target="RFC9315"/>.</t>
 
         <t>Mapping Community: Any BGP CCA (e.g., Community, Extended
-        Community) on an overlay route that maps to a Resolution Scheme. e.g.,
+        Community) on an overlay route that maps to a Resolution Scheme. For example,
         color:0:100, transport-target:0:100.</t>
 
         <t>Resolution Scheme: A construct comprising of an ordered set of
@@ -268,16 +271,16 @@
         intent.</t>
 
         <t>Service Family: A BGP address family used for advertising routes
-        for destinations in "data traffic" (e.g. AFI/SAFIs 1/1 or 1/128).</t>
+        for destinations in "data traffic". For example, AFI/SAFIs 1/1 or 1/128.</t>
 
         <t>Transport Family: A BGP address family used for advertising
-        tunnels, which are in turn used by service routes for resolution (e.g.
-        AFI/SAFIs 1/4 or 1/76).</t>
+        tunnels, which are in turn used by service routes for resolution. For example, 
+        AFI/SAFIs 1/4 or 1/76.</t>
 
         <t>Transport Tunnel : A tunnel over which a service may place traffic.
-        Such a tunnel can be provisioned or signaled using a variety of means
-        (e.g., Generic Routing Encapsulation (GRE), UDP, LDP, RSVP-TE, IGP
-        FLEX-ALGO or SRTE).</t>
+        Such a tunnel can be provisioned or signaled using a variety of means.
+        For example, Generic Routing Encapsulation (GRE), UDP, LDP, RSVP-TE, IGP
+        FLEX-ALGO or SRTE.</t>
 
         <t>Tunnel Route: A Route to Tunnel Destination/Endpoint that is
         installed at the headend (ingress) of the tunnel.</t>
@@ -296,7 +299,7 @@
         extended community as defined in this document with the "Transport
         Class ID" field set to 100.</t>
 
-        <t>Transport Route Database (TRDB): At the SN and BN, a Transport
+        <t>Transport Route Database: At the SN and BN, a Transport
         Class has an associated Transport Route Database that collects its
         Tunnel Routes.</t>
 
@@ -355,7 +358,7 @@
           Classes.</t>
 
           <t>The <xref target="ct-family">"BGP Classful Transport"</xref>
-          family to extend these constructs to adjacent domains.</t>
+          address family to extend these constructs to adjacent domains.</t>
         </list><xref target="ArchOv"/> depicts the intra-AS and inter-AS
       application of these constructs. It uses an example topology of Inter-AS
       option C network with two AS domains. AS1 is a RSVP-TE network, AS2 is a
@@ -377,16 +380,16 @@
 
       <t>The underlay route in a TRDB can be advertised in BGP to extend an
       underlay tunnel to adjacent domains. A new BGP transport layer address
-      family called "BGP Classful Transport", aka BGP CT (AFI/SAFIs 1/76,
+      family called "BGP Classful Transport", also known as BGP CT (AFI/SAFIs 1/76,
       2/76) is defined for this purpose. BGP CT makes it possible to advertise
       multiple tunnels to the same destination address, thus avoiding the need
       for multiple loopbacks on the Egress Service Node (eSN).</t>
 
-      <t>BGP CT family (AFI/SAFIs 1/76 or 2/76) carries transport prefixes
+      <t>The BGP CT address family carries transport prefixes
       across tunnel domain boundaries, which is parallel to BGP LU (AFI/SAFIs
       1/4 or 2/4). It disseminates "Transport Class" information for the
       transport prefixes across the participating domains while avoiding the
-      need of per transport class loopback, which is not possible with BGP LU.
+      need of per-transport class loopback, which is not possible with BGP LU.
       This makes the end-to-end network a "Transport Class" aware tunneled
       network.</t>
 
@@ -436,12 +439,13 @@
       consistently provisions a Transport Class on participating nodes (SNs
       and BNs) in a domain with its unique Transport Class ID.</t>
 
+      <!-- XXX JMH - this text isn't clear.  I think the intent here is to describe a specific instance of a TRDB? -->
       <t>A Transport Class is also configured with RD and import/export RT
       attributes. Creation of a Transport Class instantiates its corresponding
       TRDB and Resolution Schemes on that node.</t>
 
       <t>All nodes within a domain agree on a common Transport Class ID
-      namespace. But two co-operating domains may not always agree on the same
+      namespace. However, two co-operating domains may not always agree on the same
       namespace. Procedures to manage differences in Transport Class ID
       namespaces between co-operating domains are specified in <xref
       target="non-agreeing"/>.</t>
@@ -472,25 +476,25 @@
             the network based on RSVP-TE ERO, SR-TE policy or BGP policy.</t>
           </list></t>
 
-        <t>An operator may configure an SN/BN to classify a tunnel into an
+        <t>An operator may configure a SN/BN to classify a tunnel into an
         appropriate Transport Class. How exactly these tunnels are made
         Transport Class aware is implementation specific and outside the scope
         of this document.</t>
 
         <t>When a tunnel is made Transport Class aware, it causes the Tunnel
         Route to be installed in the corresponding TRDB of that Transport
-        Class. These routes are used to resolve overlay routes including BGP
+        Class. These routes are used to resolve overlay routes, including BGP
         CT, which may be further readvertised to adjacent domains to extend
         these tunnels. While readvertising BGP CT routes, the "Transport
         Class" identifier is encoded as part of the Transport Class RT, which
-        is a new Route Target extended community.</t>
+        is a new Route Target extended community defined in <xref target="tc-rt"/>.</t>
 
-        <t>An SN/BN receiving the transport routes via BGP with sufficient
+        <t>A SN/BN receiving the transport routes via BGP with sufficient
         signaling information to identify a Transport Class can associate
-        those tunnel routes to the corresponding Transport Class. E.g., for
-        Classful Transport family (AFI/SAFIs, 1/76 or 2/76) routes, the
+        those tunnel routes to the corresponding Transport Class. For example, 
+        Classful Transport family routes, the
         Transport Class RT indicates the Transport Class. For BGP LU family
-        (AFI/SAFIs, 1/4 or 2/4) routes, import processing based on Communities
+        routes, import processing based on Communities
         or Inter-AS source-peer may be used to place the route in the desired
         Transport Class.</t>
 
@@ -529,34 +533,31 @@
         <t>An implementation may realize the TRDB as a "Routing Table"
         referred in <eref
         target="https://www.rfc-editor.org/rfc/rfc4271#section-9.1.2.1">Section
-        9.1.2.1 of RFC4271</eref> which is "only" used for resolving next hop
+        9.1.2.1 of RFC4271</eref> which is used only for resolving next hop
         reachability in control plane. An implementation may choose a
         different datastructure to realize this logical construct while still
         adhering to the procedures defined in this document. The tunnel routes
-        in a TRDB require no footprint in forwarding plane unless they are
-        used to resolve a next hop. </t>
+        in a TRDB require no footprint in the forwarding plane unless they are
+        used to resolve a next hop.</t>
 
-        <t>SNs or BNs originate routes for 'Classful Transport' address family
+        <t>SNs or BNs originate routes for the "Classful Transport" address family
         from the TRDB. These routes have "RD:Endpoint" in the NLRI, and carry
-        a Transport Class RT and an MPLS label (or an identifier that
+        a Transport Class RT and an MPLS label, or an identifier that
         represents an equivalent of a label in a different forwarding
-        architecture). 'Classful Transport' family routes (AFI/SAFI: 1/76 or
-        2/76) received with Transport Class RT are imported into its
-        corresponding TRDB.</t>
+	architecture. "Classful Transport" family routes received with
+	Transport Class RT are installed into their respective TRDB.</t>
       </section>
 
       <section anchor="tc-rt"
                title="&quot;Transport Class&quot; Route Target Extended Community">
-        <t>This section defines a new type of Route Target, called "Transport
-        Class" Route Target Extended Community (aka Transport Target). The
+        <t>This section defines a new type of Route Target, called a "Transport
+        Class" Route Target Extended Community; also known as a Transport Target. The
         procedures for use of this extended community with BGP CT routes
-        (AFI/SAFI: 1/76 or 2/76) are described below.</t>
+        are described below.</t>
 
-        <t>"Transport Class" Route Target Extended Community is a transitive
+        <t>The "Transport Class" Route Target Extended Community is a transitive
         extended community <xref target="RFC4360">EXT-COMM</xref> of extended
         type, which has the format as shown in <xref target="TCExtCom"/>.</t>
-
-        <t>This new Route Target Format has the following encoding:</t>
 
         <figure anchor="TCExtCom" suppress-title="false"
                 title="&quot;Transport Class&quot; Route Target Extended Community">
@@ -586,17 +587,19 @@
     This document reserves the Transport class ID value 0 to
     represent "Best Effort Transport Class ID".</artwork>
         </figure>
+	<!-- XXX JMH - Best effort isn't defined in IANA considerations - should it be? -->
 
+	<!-- XXX JMH - It's unclear which RFC 4364 mechanisms are applicable. I believe the intent is to discuss how CT routes with a RT will or will not be installed in a local TRDB. The text three paragraphs below is, I believe, the applicable text. If so, I suggest not referring to RFC4364. -->
         <t>The VPN route import/export mechanisms as specified in <xref
-        target="RFC4364">BGP VPN</xref> and the Constrained Route Distribution
+        target="RFC4364">BGP/MPLS IP VPNs</xref> and the Constrained Route Distribution
         mechanisms as specified in <xref target="RFC4684">Route Target
-        Constrain</xref> can be applied to BGP CT routes (AFI/SAFI: 1/76 or
-        2/76) using its Transport Class Route Target Extended community.</t>
+	Constrain</xref> can be applied to BGP CT routes using its Transport
+	Class Route Target Extended community.</t>
 
         <t>A BGP speaker that implements <xref target="RFC4684">Route Target
         Constrain</xref> MUST also apply the RTC procedures to the Transport
-        Class Route Target Extended communities carried on BGP CT routes
-        (AFI/SAFI: 1/76 or 2/76). Further, when processing RT membership NLRIs
+        Class Route Target Extended communities carried on BGP CT routes.
+        Further, when processing RT membership NLRIs
         received from external BGP peers, it is necessary to consider multiple
         EBGP paths for a given RTC prefix for building the outbound route
         filter, and not just the best path. An implementation MAY provide
@@ -604,21 +607,22 @@
 
         <t>The Transport Class Route Target Extended community is carried on
         Classful Transport family routes and is used to associate them with
-        appropriate TRDBs at receiving BGP speakers. Transport Target is
+        appropriate TRDBs at receiving BGP speakers. The Transport Target is
         carried unaltered on the BGP CT route across BGP CT negotiated
         sessions except for scenarios described in <xref
         target="non-agreeing"/>. Implementations should provide policy
-        configuration to perform match, strip or rewrite operations on
+        mechanisms to perform match, strip, or rewrite operations on a
         Transport Target just like any other BGP community.</t>
 
         <t>Defining a new type code for the Transport Class Route Target
-        Extended community avoids conflicts with any VPN Route Target
+        Extended community avoids conflicting with any VPN Route Target
         assignments already in use for service families.</t>
 
+	<!-- XXX JMH - the text here says non-transitive is not used, but then says it should have a given behavior.-->
         <t>This document also reserves the <xref
         target="tc-rt-nt">Non-Transitive version of Transport Class extended
-        community</xref> just to block the codepoint in the non-transitive
-        namespace also. The "Non-Transitive Transport Class" Route Target
+        community</xref> for future use.
+        The "Non-Transitive Transport Class" Route Target
         Extended Community is not used. If received, it is considered
         equivalent in functionality to the Transitive Transport Class Route
         Target Extended Community, except for the difference in Transitive bit
@@ -627,7 +631,7 @@
     </section>
 
     <section anchor="Nexthop_Resoln_Schm" title="Resolution Scheme">
-      <t>Resolution Scheme is a construct that consists of a specific TRDB or
+      <t>A Resolution Scheme is a construct that consists of a specific TRDB or
       an ordered set of TRDBs. An overlay route is associated with a
       resolution scheme during import processing, based on Mapping Community
       on the route.</t>
@@ -646,27 +650,27 @@
       Classes. Two Resolution Schemes are considered equivalent in Intent if
       they consist of the same ordered set of TRDBs.</t>
 
-      <t>Operators take care that Resolution Schemes for a mapping community
-      are configured consistently on various nodes participating in a BGP CT
+      <t>Operators must ensure that Resolution Schemes for a mapping community
+      are provisioned consistently on various nodes participating in a BGP CT
       network, based on desired Intent and transport classes available in that
       domain.</t>
 
       <section anchor="Mapping_Comm" title="Mapping Community">
-        <t>'Mapping Community' is used to signal the desired Intent on an
+        <t>A "Mapping Community" is used to signal the desired Intent on an
         overlay route. At an ingress node receiving the route, it maps the
-        overlay route to a 'Resolution Scheme' used to resolve the route's
+        overlay route to a "Resolution Scheme" used to resolve the route's
         next hop.</t>
 
-        <t>Mapping community is a "role" and not a new type of community; any
+        <t>A Mapping Community is a "role" and not a new type of community; any
         BGP Community Carrying Attribute (e.g. Community or Extended
         Community) may play this role, besides the other roles it may already
-        be playing. E.g. the Transport Class Route Target Extended Community
-        plays both roles of being a Route Target as-well as a Mapping
+        be playing. For example, the Transport Class Route Target Extended Community
+        plays both roles of being a Route Target as well as a Mapping
         Community.</t>
 
         <t>Operator provisioning ensures that the ingress and egress SNs agree
-        on the BGP CCA and community namespace to use as Mapping
-        community.</t>
+        on the BGP CCA and community namespace to use for the Mapping
+        Community.</t>
 
         <t>A Mapping Community maps to exactly one Resolution Scheme at
         receiving BGP speaker. An implementation SHOULD allow associating
@@ -677,6 +681,7 @@
         <xref target="RFC9012"/>, or the "transport-target:0:100" described in
         <xref target="tc-rt"/> in this document.</t>
 
+	<!-- XXX JMH "first" community is problematic -->
         <t>The first community on an overlay route that matches a Mapping
         Community of a locally configured Resolution Scheme is considered the
         effective Mapping Community for the route. The Resolution Scheme thus
@@ -689,12 +694,13 @@
         route selection.</t>
 
         <t>If more than one distinct Mapping Communities on an overlay route
-        map to multiple Resolution Schemes with dissimilar Intents at a
+        maps to multiple Resolution Schemes with dissimilar Intents at a
         receiving node, it is considered a configuration error. Operators
         should avoid such configuration errors when attaching mapping
-        community on overlay routes.</t>
+        communities on overlay routes.</t>
 
-        <t>It should be noted that the Mapping community role does not require
+	<!-- XXX JMH - this sentence needs work. -->
+        <t>It should be noted that the Mapping Community role does not require
         applying Route Target Constrain procedures specified in RFC 4684.</t>
       </section>
     </section>
@@ -715,7 +721,7 @@
       prefixes.</t>
 
       <section anchor="ct-nlri" title="NLRI Encoding">
-        <t>The "Classful Transport" SAFI NLRI (AFI/SAFI 1/76 or 2/76) has same
+        <t>The "Classful Transport" SAFI NLRI has the same
         encoding as specified in Section 2 of <xref target="RFC8277"/>.</t>
 
         <t>When AFI/SAFI is 1/76, the Classful Transport NLRI Prefix consists
@@ -732,6 +738,7 @@
         the Multiple Labels Capability as described in Section 2.1 of <xref
         target="RFC8277"/></t>
 
+	<!-- XXX JMH - what procedure if no CT RT are present? -->
         <t>Attributes on a Classful Transport route include the Transport
         Class Route Target extended community, which is used to associate the
         route with the correct TRDBs on SNs and BNs in the network and either
@@ -757,8 +764,8 @@
         address is of type VPN-IPv4 with 8-octet RD set to zero.</t>
 
         <t>If the length of the Next hop Address field contains any other
-        values, it is considered an error and is handled as per RFC 7606
-        Section 7.11.</t>
+	values, it is considered an error and is handled via BGP session reset
+	as per <xref target="RFC7606" section="7.11"/>.</t>
       </section>
 
       <section anchor="CTMultiEncap"
@@ -768,7 +775,7 @@
         encapsulation information.</t>
 
         <t>An MPLS Label is carried using the encoding in <xref
-        target="RFC8277"/> . A node that does not support MPLS forwarding
+        target="RFC8277"/>. A node that does not support MPLS forwarding
         advertises the special label 3 (Implicit NULL) in the RFC 8277 MPLS
         Label field. The Implicit NULL label carried in BGP CT route indicates
         to receiving node that it should not impose any BGP CT label for this
@@ -798,7 +805,8 @@
         <t>AFI/SAFI 1/76 (Classful Transport SAFI) is an RFC8277 encoded
         family that carries transport prefixes in the NLRI, where the prefixes
         come from the provider namespace and are contextualized into separate
-        TRDB as per RFC4364 procedures.</t>
+        TRDB as per RFC 4364 procedures.</t>
+	<!-- XXX JMH - 4364 focuses on regular route targets.  The intent here is to say that it's similar to L3VPNs in the sense that there's a table - a TRDB - that routes - CT - are installed into based on those TRDB having associated TC routes.  I think the appropriate fix here is to avoid "as per" or other things that make an implementor see that RFC to look for normative procedures.  Instead, TRDB install, as covered below, is inspired by 4364. -->
 
         <t>It is worth noting that AFI/SAFI 1/128 has been used to carry
         transport prefixes in "L3VPN Inter-AS Carrier's carrier" scenario as
@@ -809,20 +817,20 @@
         <t>In this document, SAFI 76 (BGP CT) is used instead of reusing SAFI
         128 (L3VPN) for AFIs 1 or 2 to carry these transport routes because it
         is operationally advantageous to segregate transport and service
-        prefixes into separate address families. For e.g., such an approach
+        prefixes into separate address families. For example, such an approach
         allows operators to safely enable "per-prefix" label allocation scheme
         for Classful Transport prefixes, typically with a space complexity of
-        O(1K) to O(100K), without affecting SAFI 128 service prefixes, with a
+        O(1K) to O(100K), without affecting SAFI 128 service prefixes with a
         space complexity of O(1M). The "per prefix" label allocation scheme
-        keeps the routing churn local during topology changes.</t>
+        localizes routing churn during topology changes.</t>
 
         <t>Service routes continue to be carried in their existing AFI/SAFIs
-        without any change, e.g., L3VPN (AFI/SAFI: 1/128 and 2/128), EVPN
+        without any change. For example, L3VPN (AFI/SAFI: 1/128 and 2/128), EVPN
         (AFI/SAFI: 25/70 ), VPLS (AFI/SAFI: 25/65), Internet (AFI/SAFI: 1/1 or
-        2/1). And resolve over BGP CT (AFI/SAFI: 1/76 or 2/76) transport
+        2/1). These service routes can resolve over BGP CT (AFI/SAFI: 1/76 or 2/76) transport
         routes.</t>
 
-        <t>A new SAFI for AFI 1 and 2 also facilitates having a different
+        <t>A new SAFI for AFI 1 and AFI 2 also facilitates having a different
         readvertisement path of the transport family routes in a network than
         the service route readvertisement path. Service routes (Inet-VPN SAFI
         128) are exchanged over an EBGP multihop session between ASes with
@@ -832,8 +840,8 @@
 
         <t>The BGP CT SAFI 76 for AFI 1 and 2 is similar in vein to BGP LU
         SAFI 4, in that it carries transport prefixes. The only difference is
-        that it also carries in Route Target, an indication of which Transport
-        Class the transport prefix belongs to and uses RD to disambiguate
+        that it also carries in a Route Target an indication of which Transport
+        Class the transport prefix belongs to, and uses the RD to disambiguate
         multiple instances of the same transport prefix in a BGP Update.</t>
       </section>
     </section>
@@ -850,11 +858,11 @@
             Transport Class.</t>
 
             <t>Operators configure the Transport Classes on the SNs and BNs in
-            the network with Transport Class Route Targets and unique
+            the network with Transport Class Route Targets and appropriate
             Route-Distinguishers.</t>
 
             <t>Implementations MAY provide automatic generation and assignment
-            of RD, RT values; they MAY also provide a way to manually override
+            of RD, RT values. They MAY also provide a way to manually override
             the automatic mechanism in order to deal with any conflicts that
             may arise with existing RD, RT values in different network domains
             participating in the deployment.</t>
@@ -871,7 +879,7 @@
             protocols install tunnel routes in the TRDB associated with the
             Transport Class to which the tunnel belongs.</t>
 
-            <t>The egress node of the tunnel i.e. the tunnel endpoint (EP)
+            <t>The egress node of the tunnel, i.e. the tunnel endpoint (EP),
             originates the BGP CT route with RD:EP in the NLRI, Transport
             Class RT and PNH as EP, which will be resolved over the tunnel
             route in TRDB at the ingress node. When the tunnel is up, the
@@ -886,10 +894,10 @@
             CT route is advertised to EBGP peers and IBGP peers in neighboring
             domains.</t>
 
-            <t>This route SHOULD NOT be advertised to the IBGP core that
-            contains the tunnel, using policy configuration. Impact of not
-            prohibiting such advertisements is outside the scope of this
-            document.</t>
+	    <t>This route SHOULD NOT be advertised to the IBGP core that
+	    contains the tunnel. This may be implemented by mechanisms such as
+	    policy configuration. The impact of not prohibiting such
+	    advertisements is outside the scope of this document.</t>
 
             <t>Unique RD SHOULD be used by the originator of a Classful
             Transport route to disambiguate the multiple BGP advertisements
@@ -902,17 +910,17 @@
 
       <section title="Processing Classful Transport Routes by Ingress Nodes">
         <list>
-          <t>Upon receipt of a BGP CT route (AFI/SAFI: 1/76 or 2/76) with PNH
-          as EP that is not directly connected (e.g. an IBGP-route), Mapping
+          <t>Upon receipt of a BGP CT route with a PNH
+          EP that is not directly connected (e.g. an IBGP-route), a Mapping
           Community (the Transport Class RT) on the route is used to decide to
           which resolution scheme this route is to be mapped. </t>
 
           <t>The resolution scheme for a Transport Class RT with Transport
-          Class ID "C1" contains TRDB of Transport Class with same ID. The
+          Class ID "C1" contains the TRDB of a Transport Class with same ID. The
           administrator MAY customize the resolution scheme for Transport
-          Class "C1" to map to a different ordered list of TRDBs. If
+          Class "C1" to map to a different ordered list of TRDBs. If the
           resolution scheme for TC ID "C1" is not found, the resolution scheme
-          containing the 'Best Effort' transport class TRDB is used.</t>
+          containing the "Best Effort" transport class TRDB is used.</t>
 
           <t>The routes in the TRDBs associated with selected resolution
           scheme are used to resolve the received PNH EP. The order of TRDBs
@@ -928,7 +936,7 @@
           <t>The received BGP CT route MUST be added to the TRDB corresponding
           to the Transport Class "C1", if provisioned locally. This step
           applies only if the Transport Class RT is received on a BGP CT
-          family route (AFI/SAFI: 1/76 or 2/76). RD in the BGP CT NLRI prefix
+          family route. The RD in the BGP CT NLRI prefix
           RD:EP is ignored when the BGP CT route for EP is added to the TRDB,
           so that overlay routes can resolve over this BGP CT tunnel route by
           performing a lookup for EP. Please note that a TRDB is a logical
@@ -953,14 +961,14 @@
           semantics. The IP prefix in the TRDB context (Transport-Class,
           IP-prefix) is used as the key to do per-prefix label allocation.
           This helps in avoiding BGP CT route churn throughout the CT network
-          when an instability (e.g. link failure) is experienced in a domain.
+          when an instability (e.g., link failure) is experienced in a domain.
           The failure is not propagated further than the BN closest to the
           failure. If a different label allocation mode is used, impact on end
           to end convergence should be considered.</t>
 
           <t>The value of the advertised MPLS label is locally significant,
           and is dynamic by default. A BN may provide an option to allocate a
-          value from a statically carved out range. This can be achieved using
+          value from a statically provisioned range. This can be achieved using
           locally configured export policy, or via mechanisms such as the ones
           described in <xref target="RFC8669">BGP Prefix-SID</xref>.</t>
         </list>
@@ -968,15 +976,15 @@
 
       <section title="Border Nodes Receiving Classful Transport Routes on EBGP">
         <list>
-          <t>If a route is received with PNH that is known to be directly
-          connected (e.g. EBGP single-hop neighbor address), the directly
+          <t>If a route is received with a PNH that is known to be directly
+          connected (for example, EBGP single-hop neighbor address), the directly
           connected interface is checked for MPLS forwarding capability. No
-          other next hop resolution process is performed, as the inter-AS link
+          other next hop resolution process is performed since the inter-AS link
           can be used for any Transport Class.</t>
 
           <t>If the inter-AS links need to honor Transport Class, then the BN
           MUST follow procedures of an Ingress node described previously and
-          perform next hop resolution process. In order to make the link
+          perform the next hop resolution process. In order to make the link
           Transport Class aware, the route to directly connected PNH is
           installed in the TRDB belonging to the associated Transport
           Class.</t>
@@ -987,18 +995,18 @@
         <list>
           <t>When multiple instances of a given RD:EP exist with different
           forwarding characteristics, then <xref
-          target="RFC7911">ADDPATH</xref> is helpful.</t>
+          target="RFC7911">BGP ADD-PATH</xref> is helpful.</t>
 
           <t>When multiple BNs exist such that they advertise a "RD:EP" prefix
           to Route Reflectors (RRs), the RRs may hide all but one of the BNs,
-          unless <xref target="RFC7911">ADDPATH</xref> is used for the
+          unless <xref target="RFC7911">BGP ADD-PATH</xref> is used for the
           Classful Transport family. This is similar to L3VPN Option B
           scenarios.</t>
 
-          <t>Hence, <xref target="RFC7911">ADDPATH</xref> SHOULD be used for
-          Classful Transport family, to avoid path-hiding through RRs. Such
-          that RR sends the multiple routes for RD:EP to it's clients. This
-          improves convergence time when path via one of the multiple BNs
+          <t>Hence, <xref target="RFC7911">BGP ADD-PATH</xref> SHOULD be used for
+          Classful Transport family, to avoid path-hiding through RRs so
+          that the RR sends multiple CT routes for RD:EP to its clients. This
+          improves the convergence time when the path via one of the multiple BNs
           fails.</t>
         </list>
       </section>
@@ -1051,7 +1059,7 @@
                 <t>IGP metric should be assigned such that "ABR to redundant
                 ABR" cost is inferior to "ABR to upstream ASBR" cost.</t>
 
-                <t>Tunnels belonging to non 'best effort' Transport Classes
+                <t>Tunnels belonging to non "best effort" Transport Classes
                 SHOULD NOT be provisioned between ABRs. This will ensure that
                 the BGP CT route received from an ABR with next hop self will
                 not be usable at a redundant ABR.</t>
@@ -1062,18 +1070,18 @@
 
       <section title="Ingress Nodes Receiving Service Routes with a Mapping Community">
         <list>
-          <t>Upon receipt of a BGP service route (e.g., AFI/SAFI: 1/1, 2/1)
-          with PNH as EP that is not directly connected (e.g. an IBGP-route),
-          Mapping Community (e.g, Color Extended Community) on the route is
+          <t>Upon receipt of a BGP service route (for example, AFI/SAFI: 1/1, 2/1)
+          with a PNH as EP that is not directly connected (for example, an IBGP-route),
+          Mapping Community (for example, Color Extended Community) on the route is
           used to decide to which resolution scheme this route is to be
           mapped.</t>
 
           <t>The resolution scheme for a Color Extended Community with Color
-          "C1" contains TRDB for Transport Class with same ID, followed by
-          Best Effort TRDB. The administrator MAY customize the resolution
-          scheme to map to a different ordered list of TRDBs. If resolution
+          "C1" contains a TRDB for a Transport Class with same ID, followed by
+          the Best Effort TRDB. The administrator MAY customize the resolution
+          scheme to map to a different ordered list of TRDBs. If the resolution
           scheme for TC ID "C1" is not found, the resolution scheme containing
-          the 'Best Effort' transport class TRDB is used.</t>
+          the "Best Effort" transport class TRDB is used.</t>
 
           <t>The routes in the TRDBs associated with selected resolution
           scheme are used to resolve the received PNH EP. The order of TRDBs
@@ -1094,19 +1102,19 @@
       <section title="Best Effort Transport Class">
         <list>
           <t>It is possible to represent 'Best effort' SLA also as a Transport
-          Class. Today, BGP LU (e.g. AFI/SAFI 1/4) is used to extend the best
+          Class. Today, BGP LU (AFI/SAFI 1/4) is used to extend the best
           effort intra domain tunnels to other domains.</t>
 
-          <t>Alternatively, BGP CT (e.g. AFI/SAFI 1/76) may be used to carry
-          the best effort tunnels also. This document reserves the Transport
+          <t>Alternatively, BGP CT may also be used to carry
+          the best effort tunnels. This document reserves the Transport
           Class ID value 0 to represent "Best Effort Transport Class ID".
           However, implementations SHOULD provide configuration to use a
           different value for this purpose. Procedures to manage differences
           in Transport Class ID namespaces between domains are provided in
           <xref target="non-agreeing"/>.</t>
 
-          <t>The 'Best Effort Transport Class ID' value is used in the
-          'Transport Class ID' field of Transport Route Target Extended
+          <t>The "Best Effort Transport Class ID" value is used in the
+          "Transport Class ID" field of Transport Route Target Extended
           Community that is attached to the BGP CT route that advertises a
           best effort tunnel endpoint. The RT thus formed is called the "Best
           Effort Transport Class Route Target".</t>
@@ -1181,14 +1189,14 @@
         layers. BGP CT procedures apply equally to an IPv6 enabled Intra-AS or
         Inter-AS Option A, B, C network.</t>
 
-        <t>A BGP CT enabled network supports IPv6 service families (e.g.,
+        <t>A BGP CT enabled network supports IPv6 service families (for example,
         AFI/SAFI 2/1 or 2/128) and IPv6 transport signaling protocols like
         SRTEv6, LDPv6, RSVP-TEv6.</t>
 
         <t>Procedures in this document also apply to a network with Pure IPv6
         core, that uses MPLS forwarding for intra-domain tunnels and inter-AS
         links. BGP CTv6 family (AFI/SAFI: 2/76) is used to carry global IPv6
-        address tunnel endpoints in the NLRI. Service family routes (e.g.
+        address tunnel endpoints in the NLRI. Service family routes (for example,
         AFI/SAFI: 1/1, 2/1, 1/128, 2/128) are also advertised with those
         Global IPv6 addresses as next hop.</t>
 
@@ -1196,7 +1204,7 @@
         IPv4 core, that uses MPLS forwarding for intra-domain tunnels and
         Inter-AS links. BGP CTv6 family (AFI/SAFI: 2/76) is used to carry IPv4
         Mapped IPv6 address tunnel endpoints in the NLRI. IPv6 Service family
-        routes (e.g., AFI/SAFI: 2/1, 2/128) are also advertised with those
+        routes (for example, AFI/SAFI: 2/1, 2/128) are also advertised with those
         IPv4 Mapped IPv6 addresses as next hop.</t>
 
         <t>The PE-CE attachment circuits may use IPv4 addresses only, IPv6
@@ -1206,7 +1214,7 @@
       </section>
 
       <section anchor="SRv6-Support" title="SRv6 Support">
-        <t>This section describes how BGP CT family (e.g. AFI/SAFI 2/76) may
+        <t>This section describes how BGP CT family (AFI/SAFI 2/76) may
         be used to set up inter-domain tunnels of a certain Transport Class,
         when using Segment Routing over IPv6 (SRv6) data plane on the inter-AS
         links or as an intra-AS tunneling mechanism.</t>
@@ -1223,7 +1231,7 @@
         SID value is encoded in the "SRv6 SID Information Sub-TLV".</t>
 
         <t>It should be noted that prefixes carried in BGP CT family are
-        transport layer end-points, e.g. PE loopback addresses. Thus, the SRv6
+        transport layer end-points; i.e., PE loopback addresses. Thus, the SRv6
         SID carried in a BGP CT route is also a transport layer
         identifier.</t>
 
@@ -1286,21 +1294,21 @@
         <t>This example shows a provider MPLS network that consists of two
         ASes, AS1 and AS2. They are serving customers AS3, AS4 respectively.
         Traffic direction being described is CE41 to CE31. CE31 may request a
-        specific SLA (e.g. mapped to Gold for this example), when traversing
+        specific SLA (for example, mapped to Gold for this example), when traversing
         these provider networks.</t>
 
-        <t>AS2 is further divided into two regions. So, there are three tunnel
-        domains in provider's space. AS1 uses <xref target="RFC9350">ISIS
-        Flex-Algo</xref> intra-domain tunnels, whereas AS2 uses RSVP-TE
+        <t>AS2 is further divided into two regions. There are three tunnel
+        domains in provider's space: AS1 uses <xref target="RFC9350">ISIS
+        Flex-Algo</xref> intra-domain tunnels. AS2 uses RSVP-TE
         intra-domain tunnels. MPLS forwarding is used within these domains and
         on inter-domain links.</t>
 
         <t>The network exposes two Transport Classes: "Gold" with Transport
-        Class id 100, "Bronze" with Transport Class id 200. These Transport
+        Class ID 100, "Bronze" with Transport Class ID 200. These Transport
         Classes are provisioned at the PEs and the Border nodes (ABRs, ASBRs)
         in the network.</t>
 
-        <t>Following tunnels exist for Gold Transport Class.<list>
+        <t>The following tunnels exist for Gold Transport Class.<list>
             <t>PE25_to_ABR23_gold - RSVP-TE tunnel</t>
 
             <t>PE25_to_ABR24_gold - RSVP-TE tunnel</t>
@@ -1312,7 +1320,7 @@
             <t>ASBR14_to_PE11_gold - SRTE tunnel</t>
           </list></t>
 
-        <t>Following tunnels exist for Bronze Transport Class.<list>
+        <t>The following tunnels exist for Bronze Transport Class.<list>
             <t>PE25_to_ABR23_bronze - RSVP-TE tunnel</t>
 
             <t>ABR23_to_ASBR21_bronze - RSVP-TE tunnel</t>
@@ -1338,11 +1346,11 @@
         families (AFI: 1 and SAFIs 1, 128) with RR26.</t>
 
         <t>The PEs see each other as next hop in the BGP Update for the
-        service family routes. Addpath send, receive is enabled on both
+        service family routes. BGP ADD-PATH send and receive is enabled on both
         directions on the EBGP multihop session between RR16 and RR26 for
-        AFI:1 and SAFIs 1, 128. Addpath send is negotiated in the RR to PE
+        AFI:1 and SAFIs 1, 128. BGP ADD-PATH send is negotiated in the RR to PE
         direction in each AS. This is to avoid path hiding of service routes
-        at RR. E.g. AFI/SAFI 1/1 routes advertised by both PE11 and PE12. Or,
+        at RR; i.e., AFI/SAFI 1/1 routes advertised by both PE11 and PE12. Or,
         AFI/SAFI 1/128 routes originated by both PE11 and PE12 using same
         RD.</t>
 
@@ -1359,11 +1367,11 @@
         RD1:203.0.113.31 route is readvertised in AFI/SAFI 1/128 by PE11 with
         next hop self (192.0.2.11) and label V-L1, to RR16 with the Mapping
         Community Color:0:100 attached. RR16 advertises this route with
-        Addpath-ID to RR26 which readvertises to PE25 with next hop unchanged.
+        BGP ADD-PATH ID to RR26 which readvertises to PE25 with next hop unchanged.
         Now, PE25 can resolve the PNH 192.0.2.11 using transport routes
         received in BGP CT or BGP LU.</t>
 
-        <t>Using Addpath, service routes advertised by PE11 and PE12 for AFI:1
+        <t>Using BGP ADD-PATH, service routes advertised by PE11 and PE12 for AFI:1
         SAFIs 1, 128 reach PE25 via RR16, RR26 with the next hop unchanged, as
         PE11 or PE12.</t>
 
@@ -1459,7 +1467,7 @@
         to ASBR13, ASBR14 respectively. RR27 readvertises this BGP CT route
         also to ABR23, ABR24 with label and next hop unchanged.</t>
 
-        <t>Addpath is enabled for BGP CT family on the sessions between RR27
+        <t>BGP ADD-PATH is enabled for BGP CT family on the sessions between RR27
         and ASBRs, ABRs such that routes for 192.0.2.11:100:192.0.2.11 with
         the next hops ASBR21 and ASBR22 are reflected to ABR23, ABR24 without
         any path hiding. Thus, ABR23 is given visibility of both available
@@ -1768,11 +1776,11 @@
         provider network or span closely coordinated provider networks.</t>
 
         <t>The use of RDs also provides an option for signaling forwarding
-        diversity within the same Transport Class. An SN can advertise an EP
+        diversity within the same Transport Class. A SN can advertise an EP
         with the same Transport Class in multiple BGP CT routes with unique
         RDs.</t>
 
-        <t>For e.g., unique "RDx:EP1" prefixes can be advertised by an SN for
+        <t>For example, unique "RDx:EP1" prefixes can be advertised by an SN for
         an EP1 to different upstream BNs with unique forwarding specific
         encapsulation (e.g., Label), in order to collect traffic statistics at
         the SN for each BN. In absence of RD, duplicated Transport Class/Color
@@ -1930,12 +1938,12 @@
         <t>However, in the real world, this may not always be guaranteed. Two
         domains may independently manage their color namespaces; these are
         known as Non-Agreeing Color Domains. Two domains may have tunnels with
-        unequal set of colors; these are known as Heterogeneous Color
+        unequal sets of colors; these are known as Heterogeneous Color
         Domains.</t>
 
         <t>This section describes how BGP CT is deployed in such scenarios to
         preserve end-to-end Intent. Examples described in this section use
-        Inter-AS Option C domains. But similar mechanisms will work for
+        Inter-AS Option C domains. Similar mechanisms will work for
         Inter-AS Option A and Inter-AS Option B scenarios as well.</t>
 
         <section title="Service Layer Color Management ">
@@ -2009,7 +2017,7 @@
           resolve over Gold transport tunnels, carry a mapping community
           color:0:100500. In AS3 it maps to a resolution scheme containing
           TRDB with color 500 whereas in AS2 it maps to a TRDB with color 300
-          and in AS1 it maps to a TRDB with color 100. Co-ordination is needed
+          and in AS1 it maps to a TRDB with color 100. Coordination is needed
           to provision the resolution schemes in each domain as explained
           previously.</t>
 


### PR DESCRIPTION
Review comments on draft-23.  Some general ones are:
Reduce the amount of Latin abbreviations, or corrected its use where appropriate.
Removed redundant references to afi/safi in locations where the context was already clear.
Fixed missing definite articles in the text.

I also flagged a set of issues in the XML as "XXX JMH" that should either be resolved as part of review, or issues opened to track if they're not addressed in this pass.